### PR TITLE
Restrict to use Ruby version 3.1

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1.0
       - name: Install mdbtools
         run: sudo apt-get install mdbtools
       - name: Install gem


### PR DESCRIPTION
The rdf gem doesn't work with Ruby v 3.2 at this moment